### PR TITLE
1 : sebastian/diff is no longer using branch-alias 'master' so…

### DIFF
--- a/lib/diff/composer.json
+++ b/lib/diff/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-main": "3.0-dev"
         }
     }
 }


### PR DESCRIPTION
#1

**Issue :** 
"Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove sebastian/diff No version set (parsed as 1.0.0).."

**Fix**
sebastian/diff repo (https://github.com/sebastianbergmann/diff) is no longer using branch-alias 'master' so changed the branch-alias to 'main'